### PR TITLE
Bugfix/focus triggered reload

### DIFF
--- a/src/hooks/use-dreams.tsx
+++ b/src/hooks/use-dreams.tsx
@@ -37,7 +37,8 @@ export const useDreams = (userId: string | undefined) => {
       return data as Dream[];
     },
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };
 
@@ -92,7 +93,8 @@ export const usePaginatedDreams = (userId: string | undefined, pageSize: number 
     },
     getNextPageParam: (lastPage) => lastPage.nextPage,
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };
 
@@ -151,7 +153,8 @@ export const usePublicDreams = (pageSize: number = 20) => {
     },
     getNextPageParam: (lastPage) => lastPage.nextPage,
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };
 
@@ -217,6 +220,7 @@ export const useCommunityDreams = (pageSize: number = 10) => {
     },
     getNextPageParam: (lastPage) => lastPage.nextPage,
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };


### PR DESCRIPTION
Fixes a UI flicker where the app briefly shows a "loading..." screen after switching back to the tab from an inactive state. 

## Summary
- Added a short-circuit in the visibility change handler (`AuthContext.tsx`) to skip setting loading to `true` if reactivation happens shortly after a visibility event.
- Ensured that the `useDreams` hooks (`use-dreams.tsx`) do not refetch on window focus by setting `refetchOnWindowFocus: false` (already done).
- Reduced debounce timeout from 300ms to 100ms to make loading reset faster and prevent flashing.
