### PR TITLE
Bugfix/profile tab loading refresh

### DIFF
--- a/src/hooks/use-dreams.tsx
+++ b/src/hooks/use-dreams.tsx
@@ -37,7 +37,8 @@ export const useDreams = (userId: string | undefined) => {
       return data as Dream[];
     },
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };
 
@@ -92,7 +93,8 @@ export const usePaginatedDreams = (userId: string | undefined, pageSize: number 
     },
     getNextPageParam: (lastPage) => lastPage.nextPage,
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };
 
@@ -151,7 +153,8 @@ export const usePublicDreams = (pageSize: number = 20) => {
     },
     getNextPageParam: (lastPage) => lastPage.nextPage,
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };
 
@@ -217,6 +220,7 @@ export const useCommunityDreams = (pageSize: number = 10) => {
     },
     getNextPageParam: (lastPage) => lastPage.nextPage,
     refetchOnMount: 'always',
-    staleTime: 0
+    staleTime: 0,
+    refetchOnWindowFocus: false
   });
 };


### PR DESCRIPTION
Prevented reloads on the profile page when switching back to the tab after a few seconds. This was caused by Supabase auth events (e.g. `SIGNED_IN`, `INITIAL_SESSION`) firing during tab visibility changes. 

### Summary
- Added a `blockNextAuthRefresh` flag to ignore auth events triggered immediately after tab refocus.
- Detected tab return using `visibilitychange` and suppressed loading state changes and profile checks if the session/user hasn't changed.
- Ensured `setLoading(false)` is called consistently to avoid getting stuck in the loading state.